### PR TITLE
Run pytest in isolation

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,29 +1,43 @@
 import contextlib
 import os
-import runpy
+import subprocess
 import sys
 
-import pip_run
+import pip_run.deps
+import pip_run.launch
 from coherent.build import bootstrap
+
+
+def build_env(target, *, orig=os.environ):
+    """
+    Update environment with target on PYTHONPATH.
+    """
+    overlay = dict(
+        PYTHONPATH=pip_run.launch._path_insert(
+            orig.get('PYTHONPATH', ''), os.fspath(target)
+        ),
+    )
+    return {**orig, **overlay}
 
 
 @contextlib.contextmanager
 def project_on_path():
     """
-    Install the project under test to sys.path.
+    Install the project under test and yield its new install path.
     """
     deps = pip_run.deps.load('--editable', '.[test]')
     with bootstrap.write_pyproject(), deps as home:
-        sys.path.insert(0, str(home))
-        yield
+        yield home
 
 
 def run():
     os.environ.update(
         PYTEST_ADDOPTS='--doctest-modules',
     )
-    with project_on_path():
-        runpy.run_module('pytest', run_name='__main__')
+    with project_on_path() as home:
+        cmd = [sys.executable, '-m', 'pytest', *sys.argv[1:]]
+        proc = subprocess.Popen(cmd, env=build_env(home))
+        raise SystemExit(proc.wait())
 
 
 __name__ == '__main__' and run()

--- a/__main__.py
+++ b/__main__.py
@@ -10,12 +10,20 @@ from coherent.build import bootstrap
 
 def build_env(target, *, orig=os.environ):
     """
-    Update environment with target on PYTHONPATH.
+    Prepare the environment for invoking pytest.
+
+    Updates the environment with target on PYTHONPATH and
+    sets any system-level options.
+
+    >>> env = build_env('foo', orig=dict(PYTHONPATH='bar'))
+    >>> env['PYTHONPATH'].replace(os.pathsep, ':')
+    'foo:bar'
     """
     overlay = dict(
         PYTHONPATH=pip_run.launch._path_insert(
             orig.get('PYTHONPATH', ''), os.fspath(target)
         ),
+        PYTEST_ADDOPTS='--doctest-modules',
     )
     return {**orig, **overlay}
 
@@ -31,9 +39,6 @@ def project_on_path():
 
 
 def run():
-    os.environ.update(
-        PYTEST_ADDOPTS='--doctest-modules',
-    )
     with project_on_path() as home:
         cmd = [sys.executable, '-m', 'pytest', *sys.argv[1:]]
         proc = subprocess.Popen(cmd, env=build_env(home))


### PR DESCRIPTION
- **Invoke pytest in a subprocess to avoid interactions with imports from `coherent.*` callers.**
- **Move PYTEST_ADDOPTS to build_env and add a docstring for test.**
